### PR TITLE
feat: Mountainモデルの作成とマイグレーションの実行

### DIFF
--- a/app/models/mountain.rb
+++ b/app/models/mountain.rb
@@ -1,0 +1,2 @@
+class Mountain < ApplicationRecord
+end

--- a/db/migrate/20260316061437_create_mountains.rb
+++ b/db/migrate/20260316061437_create_mountains.rb
@@ -1,0 +1,25 @@
+class CreateMountains < ActiveRecord::Migration[7.2]
+  def change
+    create_table :mountains do |t|
+      t.string :name, null: false
+      t.integer :elevation
+      t.string :prefecture
+      t.decimal :latitude, precision: 9, scale: 6
+      t.decimal :longitude, precision: 9, scale: 6
+      t.integer :raw_physical_grade
+      t.string :raw_technical_grade
+      t.string :grade_source_prefecture
+      t.integer :normalized_physical_score
+      t.integer :normalized_technical_score
+      t.boolean :has_toilet, default: false, null: false
+      t.text :access_detail
+      t.string :image_url
+
+      t.timestamps
+    end
+      # インデックス（検索を速くする設定）も追加
+      add_index :mountains, :name
+      add_index :mountains, :prefecture
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_14_043611) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_16_061437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "mountains", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "elevation"
+    t.string "prefecture"
+    t.decimal "latitude", precision: 9, scale: 6
+    t.decimal "longitude", precision: 9, scale: 6
+    t.integer "raw_physical_grade"
+    t.string "raw_technical_grade"
+    t.string "grade_source_prefecture"
+    t.integer "normalized_physical_score"
+    t.integer "normalized_technical_score"
+    t.boolean "has_toilet", default: false, null: false
+    t.text "access_detail"
+    t.string "image_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_mountains_on_name"
+    t.index ["prefecture"], name: "index_mountains_on_prefecture"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/test/fixtures/mountains.yml
+++ b/test/fixtures/mountains.yml
@@ -1,0 +1,31 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  elevation: 1
+  prefecture: MyString
+  latitude: 9.99
+  longitude: 9.99
+  raw_physical_grade: 1
+  raw_technical_grade: MyString
+  grade_source_prefecture: MyString
+  normalized_physical_score: 1
+  normalized_technical_score: 1
+  has_toilet: false
+  access_detail: MyText
+  image_url: MyString
+
+two:
+  name: MyString
+  elevation: 1
+  prefecture: MyString
+  latitude: 9.99
+  longitude: 9.99
+  raw_physical_grade: 1
+  raw_technical_grade: MyString
+  grade_source_prefecture: MyString
+  normalized_physical_score: 1
+  normalized_technical_score: 1
+  has_toilet: false
+  access_detail: MyText
+  image_url: MyString

--- a/test/models/mountain_test.rb
+++ b/test/models/mountain_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MountainTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
山情報を管理するMountainモデルを作成
- mountainsテーブルのマイグレーション（緯度経度、グレーディング項目等）
- 地理情報（latitude/longitude）の精度を9,6に設定
- name, prefectureに検索用インデックスを追加
close #103 