### PR TITLE
feat:Diagnosesモデルの作成とマイグレーションの実行

### DIFF
--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -1,0 +1,3 @@
+class Diagnosis < ApplicationRecord
+  belongs_to :user
+end

--- a/db/migrate/20260316061437_create_mountains.rb
+++ b/db/migrate/20260316061437_create_mountains.rb
@@ -22,4 +22,3 @@ class CreateMountains < ActiveRecord::Migration[7.2]
       add_index :mountains, :prefecture
   end
 end
-

--- a/db/migrate/20260316071050_create_diagnoses.rb
+++ b/db/migrate/20260316071050_create_diagnoses.rb
@@ -1,0 +1,13 @@
+class CreateDiagnoses < ActiveRecord::Migration[7.2]
+  def change
+    create_table :diagnoses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :total_score, null: false
+      t.integer :recommended_physical_min, null: false, default: 0
+      t.integer :recommended_physical_max, null: false, default: 0
+      t.integer :recommended_technical_max, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_16_061437) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_16_071050) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "diagnoses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "total_score", null: false
+    t.integer "recommended_physical_min", default: 0, null: false
+    t.integer "recommended_physical_max", default: 0, null: false
+    t.integer "recommended_technical_max", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_diagnoses_on_user_id"
+  end
 
   create_table "mountains", force: :cascade do |t|
     t.string "name", null: false
@@ -47,4 +58,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_16_061437) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "diagnoses", "users"
 end

--- a/test/fixtures/diagnoses.yml
+++ b/test/fixtures/diagnoses.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  total_score: 1
+  recommended_physical_min: 1
+  recommended_physical_max: 1
+  recommended_technical_max: 1
+
+two:
+  user: two
+  total_score: 1
+  recommended_physical_min: 1
+  recommended_physical_max: 1
+  recommended_technical_max: 1

--- a/test/models/diagnosis_test.rb
+++ b/test/models/diagnosis_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DiagnosisTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Diagnosisモデルの作成

- ユーザーごとの診断結果を保存するテーブルを作成
- user:references によるユーザーとの関連付けおよび外部キー制約の実装
- 診断ロジックで使用する、推奨体力範囲（min/max）および技術上限値を保存するカラムを定義
 close #105 