### PR TITLE
user&mountainのカラム追加

### DIFF
--- a/db/migrate/20260412095552_add_prefecture_to_users.rb
+++ b/db/migrate/20260412095552_add_prefecture_to_users.rb
@@ -1,0 +1,5 @@
+class AddPrefectureToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :prefecture, :string
+  end
+end

--- a/db/migrate/20260412095949_add_columns_to_mountains.rb
+++ b/db/migrate/20260412095949_add_columns_to_mountains.rb
@@ -1,0 +1,8 @@
+class AddColumnsToMountains < ActiveRecord::Migration[7.2]
+  def change
+    add_column :mountains, :cable_car, :boolean
+    add_column :mountains, :name_kana, :string
+    add_column :mountains, :narrative, :text
+    add_column :mountains, :main_course, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_01_021543) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_12_095949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +69,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_01_021543) do
     t.string "image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "cable_car"
+    t.string "name_kana"
+    t.text "narrative"
+    t.string "main_course"
     t.index ["name"], name: "index_mountains_on_name"
     t.index ["normalized_physical_score"], name: "index_mountains_on_normalized_physical_score"
     t.index ["normalized_technical_score"], name: "index_mountains_on_normalized_technical_score"
@@ -85,6 +89,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_01_021543) do
     t.string "avatar_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "prefecture"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
山の詳細情報表示およびユーザー情報拡張のため、各テーブルにカラムを追加
## 内容
### ユーザー（User）
- prefecture（都道府県）
### 山（Mountain）
- cable_car（ケーブルカーの有無）
- name_kana（読み仮名）
- narrative（物語文）
- main_course（代表コース）

### 上記変更に伴いER図を更新
close #137 