### PR TITLE
推薦ロジックの実装

### DIFF
--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -32,4 +32,10 @@ class Diagnosis < ApplicationRecord
       recommended_technical_max: technical_grade
     )
   end
+
+  # ユーザーの体力レベル（1〜10）を10倍してスコア（10〜100）に変換
+  def target_physical_score
+    # minとmaxから計算
+    (recommended_physical_min + recommended_physical_max) * 5
+  end
 end

--- a/app/models/mountain.rb
+++ b/app/models/mountain.rb
@@ -4,32 +4,60 @@ class Mountain < ApplicationRecord
 
   enum :raw_technical_grade, { A: 0, B: 1, C: 2, D: 3, E: 4 }, prefix: :grade
 
+  THRESHOLD = 15
+
   # 技術度ランクを数値スコアに変換するためのマッピング
   def technical_rank_score
     self.class.raw_technical_grades[raw_technical_grade] + 1
   end
 
   def self.recommend_for(diagnosis)
-    # ユーザーの体力レベル（1〜10）を10倍してスコア（10〜100）に変換
-    target_score = (diagnosis.recommended_physical_min + diagnosis.recommended_physical_max) * 5
+    # ユーザーの体力レベル
+    target_score = diagnosis.target_physical_score
 
     # メインの検索
     mountains = where(normalized_technical_score: ..diagnosis.recommended_technical_max)
-                .where(normalized_physical_score: (target_score - 15)..(target_score + 15))
                 .order(normalized_physical_score: :desc)
-                .limit(3)
+                .limit(20)
                 .to_a
 
-    # 補充ロジック
-    if mountains.size < 3
-      additional = where(normalized_technical_score: ..diagnosis.recommended_technical_max)
-                    .where.not(id: mountains.map(&:id))
-                    .order(Arel.sql("RANDOM()"))
-                    .limit(3 - mountains.size)
-      mountains += additional.to_a
+    perfect = []
+    easy = []
+    challenge = []
+
+    mountains.each do |mountain|
+      case mountain.recommendation_type(diagnosis)
+      when :perfect
+        perfect << mountain
+      when :easy
+        easy << mountain
+      when :challenge
+        challenge << mountain
+      end
     end
 
-    mountains
+    result = []
+    result += perfect.first(2)
+    result += easy.first(3 - result.size) if result.size < 3
+    result += challenge.first(3 - result.size) if result.size < 3
+
+    result
+  end
+
+  def recommendation_type(diagnosis)
+    # ユーザーの体力レベル
+    target_score = diagnosis.target_physical_score
+
+    # 差分計算
+    difference = self.normalized_physical_score - target_score
+    # 条件分岐
+    if difference.abs <= THRESHOLD
+      :perfect
+    elsif difference < 0
+      :easy
+    else
+      :challenge
+    end
   end
 
   private

--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -53,6 +53,7 @@
                         </div>
                     </div>
                 </div>
+                <%= mountain.recommendation_type(@diagnosis) %>
 
                 <div class="px-2 pb-4">
                     <%= link_to mountain_path(mountain), class: "inline-flex items-center justify-center w-full px-6 py-3 font-bold text-slate-700 transition-all duration-200 bg-white border-2 border-slate-200 rounded-xl hover:bg-primary-500 hover:text-white hover:border-primary-500" do %>


### PR DESCRIPTION
## 概要
おすすめの山の表示ロジックを改善し、診断結果に応じてバランスよく3件表示されるように変更

## 変更内容
- Mountainモデルのrecommend_forメソッドを修正
- 山を「perfect / easy / challenge」に分類するロジックを追加
- perfectを最大2件に制限し、残りをeasy・challengeで補完するように変更
- 常に3件表示されるように調整
- recommendation_typeメソッドを追加
## 実装詳細
- 山データを一度取得後、recommendation_typeで分類
- priority順（perfect → easy → challenge）で配列を組み立て
- 不足分を順次補完することで、偏りのない推薦を実現
close #139 