### PR TITLE
プライバシーポリシーページを追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -137,3 +137,25 @@ html {
   .favorite-btn-reset{
     @apply w-full h-full cursor-pointer flex items-center justify-center
   }
+
+  .legal-title {
+    @apply border border-primary-80 rounded-3xl py-6 text-primary-1100;
+    background: linear-gradient(to bottom, var(--color-primary-200), var(--color-primary-60));
+  }
+
+  .privacy-box {
+    @apply border border-primary-80 rounded-3xl bg-primary-1100 p-4
+  }
+
+  .privacy-title {
+    @apply border-b-2 border-primary-80 pb-2 text-primary-40 font-bold text-lg
+  }
+
+  .privacy-text {
+    @apply pt-2
+  }
+
+  .privacy-list {
+  list-style: disc;
+  padding-left: 1rem;
+  }

--- a/app/controllers/legal_controller.rb
+++ b/app/controllers/legal_controller.rb
@@ -1,0 +1,7 @@
+class LegalController < ApplicationController
+  def privacy
+  end
+
+  def terms
+  end
+end

--- a/app/helpers/legal_helper.rb
+++ b/app/helpers/legal_helper.rb
@@ -1,0 +1,2 @@
+module LegalHelper
+end

--- a/app/views/legal/privacy.html.erb
+++ b/app/views/legal/privacy.html.erb
@@ -1,0 +1,89 @@
+<div class="min-h-screen font-mincho pb-6 max-w-xs md:max-w-4xl mx-auto text-sm">
+    <div class="text-center my-6 legal-title">
+        <div class="text-3xl">
+            プライバシーポリシー
+        </div>
+        <p class="text-sm">Privacy Policy</p>
+    </div>
+    <div class="flex flex-col gap-6">
+        <div class="privacy-box">
+            <p class="">
+                やまッチ（以下「本サービス」という）では、本サービスで取得する皆さまの情報（以下「ユーザー情報」という）の取り扱いに際し、<br>個人情報が慎重かつ適切に取り扱われるべき重要な情報であることを認識し、<br>個人情報に関する法令および所轄官庁のガイドラインを遵守するとともに、以下に定める方針に従って個人情報の保護に努めます。
+            </p>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第1条（個人情報）</div>
+            <p class="privacy-text">
+                「個人情報」とは，個人情報保護法にいう「個人情報」を指すものとし，生存する個人に関する情報であって，<br>当該情報に含まれる氏名，生年月日，住所，電話番号，連絡先その他の記述等により特定の個人を識別できる情報及び容貌，指紋，声紋にかかるデータ，及び健康保険証の保険者番号などの当該情報単体から特定の個人を識別できる情報（個人識別情報）を指します。
+            </p>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第2条（個人情報の収集方法）</div>
+            <p class="privacy-text">
+                当社は，ユーザーが利用登録をする際にニックネーム，メールアドレス，パスワード、都道府県、利用状況（診断結果・お気に入り等）などの個人情報をお尋ねすることがあります。また，ユーザーと提携先などとの間でなされたユーザーの個人情報を含む取引記録や決済に関する情報を,当社の提携先（情報提供元，広告主，広告配信先などを含みます。以下，｢提携先｣といいます。）などから収集することがあります。
+            </p>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第3条（個人情報を収集・利用する目的）</div>
+            <div class="privacy-text">
+                <p>当社が個人情報を収集・利用する目的は，以下のとおりです。</p>
+                <ul class="privacy-list">
+                    <li>診断結果の算出・表示のため</li>
+                    <li>お気に入り機能の提供のため</li>
+                    <li>ユーザーが選択した都道府県情報に基づき、山との距離を算出・表示するため</li>
+                    <li>ユーザーからのお問い合わせに回答するため（本人確認を行うことを含む）</li>
+                    <li>ユーザーが利用中のサービスの新機能，更新情報,及び当社が提供する他のサービスの案内のメールを送付するため</li>
+                    <li>メンテナンス，重要なお知らせなど必要に応じたご連絡のため</li>
+                    <li>利用規約に違反したユーザーや，不正・不当な目的でサービスを利用しようとするユーザーの特定をし，ご利用をお断りするため</li>
+                    <li>ユーザーにご自身の登録情報の閲覧や変更，削除，ご利用状況の閲覧を行っていただくため</li>
+                    <%# <li>有料サービスにおいて，ユーザーに利用料金を請求するため</li> %>
+                    <li>上記の利用目的に付随する目的</li>
+                </ul>
+            </div>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第4条（利用目的の変更）</div>
+            <ul class="privacy-text privacy-list">
+                <li>当社は，利用目的が変更前と関連性を有すると合理的に認められる場合に限り，個人情報の利用目的を変更するものとします。</li>
+                <li>利用目的の変更を行った場合には，変更後の目的について，当社所定の方法により，ユーザーに通知し，または本ウェブサイト上に公表するものとします。</li>
+            </ul>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第5条（個人情報の第三者提供）</div>
+            <div class="privacy-text">
+                <p>当社は，次に掲げる場合を除いて，あらかじめユーザーの同意を得ることなく，第三者に個人情報を提供することはありません。ただし，個人情報保護法その他の法令で認められる場合を除きます。</p>
+                <ul class="privacy-list">
+                    <li>法令に基づく場合</li>
+                    <li>人の生命・身体・財産の保護が必要な場合</li>
+                    <li>公衆衛生・児童の健全育成のために必要な場合</li>
+                    <li>国・地方公共団体への協力が必要な場合</li>
+                </ul>
+            </div>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第6条（個人情報の開示）</div>
+            <p class="privacy-text">
+                ご本人から請求があった場合、遅滞なく個人情報を開示します。ただし、本人や第三者の権利を害する場合や、当社の業務・法令に支障をきたす場合は、その全部または一部を開示しないことがあり、その際は通知します。</p>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第7条（訂正および削除）</div>
+            <p class="privacy-text">ユーザーは、自身の個人情報が誤っている場合、当社所定の手続きで訂正・追加・削除を請求できます。当社が必要と判断した場合は遅滞なく対応し、その結果を通知します。</p>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第8条（利用停止等）</div>
+            <p class="privacy-text">
+                個人情報が目的外に利用、または不正に取得されたとして利用停止・消去を求められた場合、当社は速やかに調査を行い、必要に応じて対応します。対応の可否については遅滞なく通知します。</p>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第9条（ポリシーの変更）</div>
+            <p class="privacy-text">本ポリシーの内容は、法令等に定めがある場合を除き、ユーザーに通知することなく変更できます。変更後の内容は、本サイトに掲載した時点から効力を生じるものとします。</p>
+        </div>
+        <div class="privacy-box">
+            <div class="privacy-title">第10条（お問い合わせ窓口）</div>
+            <div class="privacy-text">
+                <p>本ポリシーに関するお問い合わせは，下記の窓口までお願いいたします。</p>
+                <p>tahaidao075@gmail.com</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/legal/terms.html.erb
+++ b/app/views/legal/terms.html.erb
@@ -1,0 +1,2 @@
+<h1>Legal#terms</h1>
+<p>Find me in app/views/legal/terms.html.erb</p>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,8 +2,8 @@
   <div class="footer-content">
     <div class="footer-links">
       <div class="link-group flex justify-center gap-2 md:gap-6">
-        <%= link_to '利用規約', "#", class: "nav-link" %>
-        <%= link_to 'プライバシーポリシー', "#", class: "nav-link" %>
+        <%= link_to '利用規約', legal_terms_path, class: "nav-link" %>
+        <%= link_to 'プライバシーポリシー', legal_privacy_path, class: "nav-link" %>
         <%= link_to 'お問い合わせ', "#", class: "nav-link" %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+
   # Deviseのルーティング（これが必須）
   devise_for :users
 
@@ -16,6 +17,8 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   root "pages#top"
+  get "legal/privacy"
+  get "legal/terms"
   resources :diagnoses, only: [ :new, :create, :show ]
   resource :profile, only: [ :show, :edit, :update ]
   resources :mountains, only: [ :index, :show ]
@@ -24,4 +27,5 @@ Rails.application.routes.draw do
     resource :favorite, only: [ :create, :destroy ]
   end
   resources :favorites, only: [ :index ]
+
 end

--- a/test/controllers/legal_controller_test.rb
+++ b/test/controllers/legal_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class LegalControllerTest < ActionDispatch::IntegrationTest
+  test "should get privacy" do
+    get legal_privacy_url
+    assert_response :success
+  end
+
+  test "should get terms" do
+    get legal_terms_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
##  概要
プライバシーポリシーページを新規作成し、内容を記載し、閲覧できるように
## 背景
サービス運用においてプライバシーポリシーの明示が必要なため
## 実装内容
- コントローラー・ビューをジェネレーターで作成
- ルーティングを追加
- プライバシーポリシーの内容をビューに記載
- レイアウトを調整
- フッターにリンクを追加し、遷移できるように実装
## 確認方法
- フッターのリンクからプライバシーポリシーページに遷移できること
- ページ内容が表示されること
close #92