### PR TITLE
メール送信ドメインとリンクURLの設定を本番用に変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,7 @@ config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 # Disable caching for Action Mailer templates even if Action Controller
 # caching is enabled.
 # 本番環境のホスト名を指定（自身のドメインに書き換えてください）
-config.action_mailer.default_url_options = { host: "your-app-domain.com", protocol: "https" }
+config.action_mailer.default_url_options = { host: "yamatchapp.com", protocol: "https" }
 
 # Resendを使用するための設定
 config.action_mailer.delivery_method = :resend


### PR DESCRIPTION
## 概要
独自ドメインを用いたメール送信設定を本番環境に適用
## 変更内容
- ActionMailerのhostを yamatchapp.com に変更
- .env の MAIL_FROM を本番ドメインに変更
## 前提
- 独自ドメイン取得済み
- DNS設定・Resend認証完了済み
## 補足
- ローカル環境では localhost のまま動作する可能性あり
close #146 
close #181 