### PR TITLE
登山ログ詳細ページを作成

### DIFF
--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -1,6 +1,6 @@
 class ActivityRecordsController < ApplicationController
   def index
-    @activity_records = current_user.activity_records
+    @activity_records = current_user.activity_records.includes(photos: :image_attachment)
   end
 
   def new
@@ -31,6 +31,10 @@ class ActivityRecordsController < ApplicationController
   rescue ActiveRecord::RecordInvalid
     # 再表示（エラー情報を持ったまま返す）
     render :new, status: :unprocessable_entity
+  end
+
+  def show
+    @activity_record = current_user.activity_records.includes(photos: :image_attachment).find(params[:id])
   end
 
   private

--- a/app/helpers/activity_records_helper.rb
+++ b/app/helpers/activity_records_helper.rb
@@ -1,2 +1,5 @@
 module ActivityRecordsHelper
+  def weekdays
+    ["日", "月", "火", "水", "木", "金", "土"]
+  end
 end

--- a/app/views/activity_records/index.html.erb
+++ b/app/views/activity_records/index.html.erb
@@ -3,6 +3,7 @@
     <% if @activity_records.any? %>
     <div class="grid md:grid-cols-3 gap-6">
         <% @activity_records.each do |activity_record| %>
+        <%= link_to activity_record_path(activity_record) do %>
         <div class="p-6 font-mincho">
             <%# 画像 %>
             <% photo = activity_record.photos.first %>
@@ -19,6 +20,7 @@
             <%= activity_record.climbed_at %>
             <% end %>
         </div>
+        <% end %>
     </div>
     <% else %>
     <p>登山記録はまだありません</p>

--- a/app/views/activity_records/show.html.erb
+++ b/app/views/activity_records/show.html.erb
@@ -1,0 +1,57 @@
+<div class="min-h-screen font-mincho">
+    <div class="max-w-6xl mx-auto pt-10 pb-10 px-7">
+        <%# 日付・山名 %>
+        <div class="flex justify-between items-center border-b-2 border-primary-90 py-4">
+          <div class="">
+            <p class="text-lg">
+              <%= @activity_record.climbed_at.strftime("%Y年%m月%d日") %>
+              <%= weekdays[@activity_record.climbed_at.wday] %>曜日
+            </p>
+          </div>
+          <p class="text-3xl font-bold">
+            <%= @activity_record.mountain.name%>
+          </p>
+        </div>
+        <%# タイトル・山情報 %>
+        <div class="flex flex-col py-4">
+          <p class="text-2xl font-bold">
+            <%= @activity_record.title%>
+          </p>
+          <p class="text-sm text-primary-90/70 p-1">
+            標高<%= @activity_record.mountain.elevation%>m
+            <%# 天候 %>
+            <%# 所要時間 %>
+          </p>
+          <%# 削除・編集 %>
+        </div>
+        <%# 画像 %>
+        <div class="">
+            <%# メイン %>
+            <div class="">
+                <% main_photo = @activity_record.photos.first %>
+                <% sub_photos = @activity_record.photos.drop(1) %>
+                <div>
+                    <% if main_photo&.image&.attached? %>
+                      <%= image_tag main_photo.image, class: "w-full h-[610px] object-cover md:rounded-3xl" %>
+                    <% else %>
+                      <%= image_tag "sample/default.jpg", class: "w-full h-[610px] object-cover md:rounded-3xl" %>
+                    <% end %>
+                </div>
+            </div>
+            <%# サブ %>
+            <div class="md:flex gap-4 py-10">
+                <% sub_photos.each do |photo|%>
+                  <%if photo.image.attached?%>
+                    <%= image_tag photo.image, class: "w-full h-60 object-cover md:rounded-2xl pb-2" %>
+                  <% end %>
+                <% end %>
+            </div>
+        </div>
+
+        <%# 内容 %>
+        <div class="kamon-rule mb-8"><span class="font-mincho text-xs tracking-[0.3em]">◆</span></div>
+        <div class="max-w-3xl mx-auto leading-8 text-[15px]">
+          <%= simple_format(@activity_record.body) %>
+        </div>
+    </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,5 @@ Rails.application.routes.draw do
     resource :favorite, only: [ :create, :destroy ]
   end
   resources :favorites, only: [ :index ]
-  resources :activity_records, only: [ :index, :new, :create ]
+  resources :activity_records, only: [ :index, :new, :create, :show ]
 end


### PR DESCRIPTION
## 概要

登山ログ詳細ページを作成しました。

## 実装内容

- 活動記録詳細ページ追加
- メイン画像・サブ画像表示
- 日付フォーマット調整
- 山情報表示
- 本文レイアウト調整
- N+1対策で includes を追加

## UI調整

- 写真を主役にしたレイアウト
- 余白を広めに調整
- 装飾として ◆ を追加
close #156