### PR TITLE
Issue 157 activity logs edit

### DIFF
--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -1,4 +1,6 @@
 class ActivityRecordsController < ApplicationController
+  before_action :set_activity_record, only: [:show, :edit, :update]
+
   def index
     @activity_records = current_user.activity_records.includes(photos: :image_attachment)
   end
@@ -15,7 +17,7 @@ class ActivityRecordsController < ApplicationController
       @activity_record = current_user.activity_records.new(activity_record_params)
 
       # 画像データの整形（nil除去・最大3枚）
-      images = Array(params[:activity_record][:images]).reject(&:blank?).first(3)
+      images = Array(params[:activity_record][:images]).reject(&:blank?)
 
       # 画像を関連として紐付け（まだ保存しない）
       images.each do |image|
@@ -34,7 +36,38 @@ class ActivityRecordsController < ApplicationController
   end
 
   def show
-    @activity_record = current_user.activity_records.includes(photos: :image_attachment).find(params[:id])
+  end
+
+  def edit
+  end
+
+  def update
+    delete_photo_ids = params[:activity_record][:delete_photo_ids].to_s.split(",").reject(&:blank?)
+    images = Array(params[:activity_record][:images]).reject(&:blank?)
+
+    # トランザクションを開始して、失敗したらすべて無かったことにする
+    ActiveRecord::Base.transaction do
+      # 削除の処理
+      delete_photo_ids.each do |photo_id|
+        photo = @activity_record.photos.find_by(id: photo_id)
+        photo.destroy! if photo
+      end
+
+      # 画像の追加保存（仮登録）
+      images.each do |image|
+        @activity_record.photos.build(image: image)
+      end
+
+      # フォームの他の項目（titleなど）をセットし、バリデーションを実行
+      @activity_record.assign_attributes(activity_record_params)
+
+      # 全体まとめて保存（バリデーション実行）
+      @activity_record.save!
+      redirect_to activity_record_path(@activity_record), notice: "登山記録を更新しました"
+    end
+  rescue ActiveRecord::RecordInvalid
+    # 再表示（エラー情報を持ったまま返す）
+    render :edit, status: :unprocessable_entity
   end
 
   private
@@ -46,5 +79,9 @@ class ActivityRecordsController < ApplicationController
       :climbed_at,
       :mountain_id,
     )
+  end
+
+  def set_activity_record
+    @activity_record = current_user.activity_records.includes(photos: :image_attachment).find(params[:id])
   end
 end

--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -1,5 +1,5 @@
 class ActivityRecordsController < ApplicationController
-  before_action :set_activity_record, only: [:show, :edit, :update]
+  before_action :set_activity_record, only: [ :show, :edit, :update ]
 
   def index
     @activity_records = current_user.activity_records.includes(photos: :image_attachment)

--- a/app/helpers/activity_records_helper.rb
+++ b/app/helpers/activity_records_helper.rb
@@ -1,5 +1,5 @@
 module ActivityRecordsHelper
   def weekdays
-    ["日", "月", "火", "水", "木", "金", "土"]
+    [ "日", "月", "火", "水", "木", "金", "土" ]
   end
 end

--- a/app/javascript/controllers/activity_record_controller.js
+++ b/app/javascript/controllers/activity_record_controller.js
@@ -8,15 +8,22 @@ export default class extends Controller {
     "mountain",
     "title",
     "images",
-    "preview",
+    "newPreview",
+    "existingPreview",
     "imageError",
-    "removeImage"
+    "removeImage",
+    "deletePhotoIds"
   ]
   connect() {
     this.selectedFiles = []
     this.checkForm()
     // 生成したURLを追跡するための配列（掃除用）
     this.previewUrls = []
+    this.photoIds = []
+    // 削除予約リスト
+    this.deletedPhotoIds = []
+    // DOM（HTML）に埋め込まれた初期データを読む
+    this.existingCount = Number(this.element.dataset.existingCount)
   }
 
   // 入力チェック
@@ -40,7 +47,7 @@ export default class extends Controller {
     this.imageErrorTarget.textContent = "";
 
     // 1. 現在の枚数 + 新しく選んだ枚数が3枚を超える場合はエラー
-    if (this.selectedFiles.length + newFiles.length > 3 ) {
+    if (this.totalImages() + newFiles.length > 3 ) {
       this.imageErrorTarget.textContent = "画像は3枚までです"
       // inputの中身を現在の配列(selectedFiles)の状態に戻す
       this.syncInput()
@@ -74,7 +81,7 @@ export default class extends Controller {
     // 既存のURLを一度すべて解放してリセット
     this.clearPreviewUrls()
 
-    this.previewTarget.innerHTML = ""
+    this.newPreviewTarget.innerHTML = ""
 
     this.selectedFiles.forEach((file, index) => {
       const imageUrl = URL.createObjectURL(file)
@@ -92,8 +99,15 @@ export default class extends Controller {
         </button>
       </div>`
 
-      this.previewTarget.insertAdjacentHTML('beforeend', previewHtml)
+      this.newPreviewTarget.insertAdjacentHTML('beforeend', previewHtml)
     })
+  }
+
+  totalImages() {
+    const remainingExisting = this.existingCount - this.deletedPhotoIds.length
+    const total = remainingExisting + this.selectedFiles.length
+
+    return total
   }
 
   // 生成されたオブジェクトURLをすべて無効化する
@@ -105,11 +119,23 @@ export default class extends Controller {
   // 削除処理
   removeImage(event) {
     const index = Number(event.currentTarget.dataset.index)
-    // 配列から削除
-    this.selectedFiles.splice(index, 1)
-    // 同期と再描画
-    this.syncInput()
-    this.renderPreview()
+    const photoId = event.currentTarget.dataset.photoId
+
+    if (photoId) {
+      // DB画像
+      this.deletedPhotoIds.push(photoId)
+      // 値を詰め込むイメージ（removeImage関数の中）
+      this.deletePhotoIdsTarget.value = this.deletedPhotoIds.join(",")
+      // 画面から削除
+      event.currentTarget.parentElement.remove()
+    } else {
+      // 新規画像, 配列から削除
+      this.selectedFiles.splice(index, 1)
+
+      // 同期と再描画
+      this.syncInput()
+      this.renderPreview()
+    }
   }
 
   disconnect() {

--- a/app/models/activity_record.rb
+++ b/app/models/activity_record.rb
@@ -18,7 +18,7 @@ class ActivityRecord < ApplicationRecord
 
   def photos_limit
     if photos.length > 3
-      errors.add(:photos, "は3枚までです")
+      errors.add(:base, "画像は3枚までです")
     end
   end
 end

--- a/app/views/activity_records/edit.html.erb
+++ b/app/views/activity_records/edit.html.erb
@@ -1,11 +1,11 @@
 <div class="min-h-screen font-mincho">
     <div class="cover">
         <div class="page-title pl-4">
-            <p class="text-2xl">登山記録 新規作成</p>
+            <p class="text-2xl">登山記録 編集</p>
             <p class="text-sm">- 山行の記憶を残しましょう</p>
         </div>
         <div>
-            <%= form_with model: @activity_record, data: { controller: "activity-record", existing_count: 0 } do |f| %>
+            <%= form_with model: @activity_record, data: { controller: "activity-record"} do |f| %>
             <div class="text-primary-1000">
                 <% if @activity_record.errors.any? %>
                 <ul>
@@ -50,17 +50,32 @@
 
                 <%# 写真投稿 %>
                 <div class="activity_record-frame">
-                    <div class="grid grid-cols-3 gap-2" data-activity-record-target="newPreview">
-                        <%# プレビュー表示用エリア %>
+                    <div class="grid grid-cols-3 gap-2" data-activity-record-target="existingPreview"
+                        data-existing-count="<%= @activity_record.photos.count %>">
+                        <%# 既存プレビュー表示用エリア %>
+                        <% @activity_record.photos.select(&:persisted?).each do |photo| %>
+                        <div class="relative border border-primary-300/20 rounded-xl justify-self-start p-2">
+                            <%= image_tag photo.image, class: "w-32 h-32 object-cover rounded" %>
+                            <button type="button"
+                                class="absolute -top-1 -right-2 bg-primary-90 text-primary-10 rounded-full w-6 h-6 cursor-pointer"
+                                data-action="click->activity-record#removeImage" data-photo-id="<%= photo.id %>">
+                                ✕
+                            </button>
+                        </div>
+                        <% end %>
                     </div>
+                    <div class="grid grid-cols-3 gap-2" data-activity-record-target="newPreview">
+                        <%# 新規プレビュー表示用エリア %>
+                    </div>
+
                     <div class="text-primary-1000 text-center" data-activity-record-target="imageError">
                         <%# サーバー側のバリデーションエラー（:base）があればここに表示 %>
                         <% if @activity_record.errors[:base].any? %>
-                            <% @activity_record.errors[:base].each do |message| %>
-                                <% if message.include?("画像") %>
-                                    <p class="text-sm font-bold text-red-500"><%= message %></p>
-                                <% end %>
+                          <% @activity_record.errors[:base].each do |message| %>
+                            <% if message.include?("画像") %>
+                              <p class="text-sm font-bold text-red-500"><%= message %></p>
                             <% end %>
+                          <% end %>
                         <% end %>
                     </div>
                     <p class="activity_record-title"><%= f.label :photos %></p>
@@ -74,8 +89,10 @@
                     </label>
                 </div>
             </div>
+            <%# 削除したいIDをカンマ区切りの文字列などで保持する隠しフィールド %>
+            <%= hidden_field_tag 'activity_record[delete_photo_ids]', '', data: { activity_record_target: "deletePhotoIds" } %>
             <div class="pt-6">
-                <%= f.submit "登山記録を作成する", class: "activity_record-button disabled:opacity-20", data: { activity_record_target: "submitButton" }%>
+                <%= f.submit "登山記録を更新する", class: "activity_record-button disabled:opacity-20", data: { activity_record_target: "submitButton" }%>
             </div>
             <% end %>
         </div>

--- a/app/views/activity_records/edit.html.erb
+++ b/app/views/activity_records/edit.html.erb
@@ -64,7 +64,7 @@
                         </div>
                         <% end %>
                     </div>
-                    <div class="grid grid-cols-3 gap-2" data-activity-record-target="newPreview">
+                    <div class="grid grid-cols-3 gap-2 pt-2" data-activity-record-target="newPreview">
                         <%# 新規プレビュー表示用エリア %>
                     </div>
 

--- a/app/views/activity_records/show.html.erb
+++ b/app/views/activity_records/show.html.erb
@@ -23,6 +23,9 @@
             <%# 所要時間 %>
           </p>
           <%# 削除・編集 %>
+          <div class="">
+            <%= link_to '編集', edit_activity_record_path(@activity_record), class: 'link' %>
+          </div>
         </div>
         <%# 画像 %>
         <div class="">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,5 @@ Rails.application.routes.draw do
     resource :favorite, only: [ :create, :destroy ]
   end
   resources :favorites, only: [ :index ]
-  resources :activity_records, only: [ :index, :new, :create, :show ]
+  resources :activity_records, only: [ :index, :new, :create, :show, :edit, :update ]
 end


### PR DESCRIPTION
## 概要
登山記録（ActivityRecord）の新規作成および編集画面において、複数画像の投稿・編集機能と、枚数・ファイルサイズの制限を実装しました。
JavaScript（フロント）による快適な操作性と、Rails（バックエンド）のバリデーションによる堅牢な二重チェックを両立しています。

## 変更内容

### 1. フロントエンド（UI/UX向上）
- **リアルタイムプレビュー**: 画像選択時に画面をリロードすることなく、選択した画像のプレビューを表示。
- **動的な枚数計算**: 既存の画像枚数と、新しく選択した画像の枚数をJavaScript側で動的に合算し、合計3枚を超える場合はその場で選択をブロック。
- **サイズチェック**: 5MBを超えるファイルが含まれている場合に警告を出し、未然に送信を防ぐ仕組みを導入。

### 2. バックエンド（データ整合性と堅牢性の担保）
- **編集時の一括削除予約システム**: 編集画面での既存画像削除時、即座にDBへ反映するのではなく、隠しフィールド（`delete_photo_ids`）にIDを蓄積して送信時に一括処理する設計を採用。
- **トランザクションの導入**: 画像の削除、新規追加、文字データの更新を同一トランザクション（`ActiveRecord::Base.transaction`）内で実行。いずれかが失敗した場合は、完全にロールバック（巻き戻し）が行われる安全な設計に。
- **モデルバリデーションの強化**: JavaScriptをすり抜けた不正なリクエストに対しても、モデル側（`:base`）で「画像は3枚までです」と検知し、適切にエラーメッセージを出し分ける二重ガードを構築。

### 3. その他
- `rubocop --auto-correct` を実行し、プロジェクトのコードスタイルに沿ったコードフォーマットのクリーンアップを実施。

## 確認したこと（テスト内容）
1. 新規作成時に3枚以内の画像が正しくプレビューされ、保存できること。
2. 編集画面で、既存画像を削除しつつ新しい画像を追加（トータル3枚以内）して更新できること。
3. フロントの制限をすり抜けて4枚以上の画像を送信した場合、Rails側でエラー（「画像は3枚までです」）が発生し、データがロールバックされて元のフォームにエラーが表示されること。

close #157 
close #159