### PR TITLE
登山ログの削除機能を追加、あわせてフラッシュメッセージの共通化とレイアウト調整

### DIFF
--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -1,5 +1,5 @@
 class ActivityRecordsController < ApplicationController
-  before_action :set_activity_record, only: [ :show, :edit, :update ]
+  before_action :set_activity_record, only: [ :show, :edit, :update, :destroy ]
 
   def index
     @activity_records = current_user.activity_records.includes(photos: :image_attachment)
@@ -68,6 +68,11 @@ class ActivityRecordsController < ApplicationController
   rescue ActiveRecord::RecordInvalid
     # 再表示（エラー情報を持ったまま返す）
     render :edit, status: :unprocessable_entity
+  end
+
+  def destroy
+    @activity_record.destroy
+    redirect_to activity_records_path, notice: "登山記録を削除しました"
   end
 
   private

--- a/app/views/activity_records/index.html.erb
+++ b/app/views/activity_records/index.html.erb
@@ -9,7 +9,7 @@
             <% photo = activity_record.photos.first %>
             <div class="">
                 <% if photo&.image&.attached? %>
-                <%= image_tag photo.image, class: "w-full h-60 rounded-3xl opacity-50 object-cover" %>
+                <%= image_tag photo.image, class: "w-full h-60 rounded-3xl object-cover" %>
                 <% else %>
                 <%= image_tag "sample/default.jpg", class: "w-full h-60 rounded-3xl opacity-50 object-cover" %>
                 <% end %>

--- a/app/views/activity_records/show.html.erb
+++ b/app/views/activity_records/show.html.erb
@@ -2,30 +2,34 @@
     <div class="max-w-6xl mx-auto pt-10 pb-10 px-7">
         <%# 日付・山名 %>
         <div class="flex justify-between items-center border-b-2 border-primary-90 py-4">
-          <div class="">
-            <p class="text-lg">
-              <%= @activity_record.climbed_at.strftime("%Y年%m月%d日") %>
-              <%= weekdays[@activity_record.climbed_at.wday] %>曜日
+            <div class="">
+                <p class="text-lg">
+                    <%= @activity_record.climbed_at.strftime("%Y年%m月%d日") %>
+                    <%= weekdays[@activity_record.climbed_at.wday] %>曜日
+                </p>
+            </div>
+            <p class="text-3xl font-bold">
+                <%= @activity_record.mountain.name%>
             </p>
-          </div>
-          <p class="text-3xl font-bold">
-            <%= @activity_record.mountain.name%>
-          </p>
         </div>
         <%# タイトル・山情報 %>
-        <div class="flex flex-col py-4">
-          <p class="text-2xl font-bold">
-            <%= @activity_record.title%>
-          </p>
-          <p class="text-sm text-primary-90/70 p-1">
-            標高<%= @activity_record.mountain.elevation%>m
-            <%# 天候 %>
-            <%# 所要時間 %>
-          </p>
-          <%# 削除・編集 %>
-          <div class="">
-            <%= link_to '編集', edit_activity_record_path(@activity_record), class: 'link' %>
-          </div>
+        <div class="flex items-center justify-between py-4">
+            <div class="flex flex-col">
+                <p class="text-2xl font-bold">
+                    <%= @activity_record.title%>
+                </p>
+                <p class="text-sm text-primary-90/70 p-1">
+                    標高<%= @activity_record.mountain.elevation%>m
+                    <%# 天候 %>
+                    <%# 所要時間 %>
+                </p>
+            </div>
+
+            <%# 削除・編集 %>
+            <div class="flex items-center gap-4">
+                <%= link_to '編集', edit_activity_record_path(@activity_record), class: 'hover:text-primary-70' %>
+                <%= link_to '削除', activity_record_path(@activity_record),data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: 'hover:text-primary-1000' %>
+            </div>
         </div>
         <%# 画像 %>
         <div class="">
@@ -35,18 +39,20 @@
                 <% sub_photos = @activity_record.photos.drop(1) %>
                 <div>
                     <% if main_photo&.image&.attached? %>
-                      <%= image_tag main_photo.image, class: "w-full h-[610px] object-cover md:rounded-3xl" %>
+                    <%= image_tag main_photo.image, class: "w-full h-[610px] object-cover md:rounded-3xl" %>
                     <% else %>
-                      <%= image_tag "sample/default.jpg", class: "w-full h-[610px] object-cover md:rounded-3xl" %>
+                    <%= image_tag "sample/default.jpg", class: "w-full h-[610px] object-cover opacity-50 md:rounded-3xl" %>
                     <% end %>
                 </div>
             </div>
             <%# サブ %>
-            <div class="md:flex gap-4 py-10">
-                <% sub_photos.each do |photo|%>
-                  <%if photo.image.attached?%>
-                    <%= image_tag photo.image, class: "w-full h-60 object-cover md:rounded-2xl pb-2" %>
-                  <% end %>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 py-10 w-full">
+                <% sub_photos.each do |photo| %>
+                    <% if photo.image.attached? %>
+                        <div class="min-w-0">
+                            <%= image_tag photo.image, class: "w-full aspect-[3/2] object-cover md:rounded-2xl" %>
+                        </div>
+                    <% end %>
                 <% end %>
             </div>
         </div>
@@ -54,7 +60,7 @@
         <%# 内容 %>
         <div class="kamon-rule mb-8"><span class="font-mincho text-xs tracking-[0.3em]">◆</span></div>
         <div class="max-w-3xl mx-auto leading-8 text-[15px]">
-          <%= simple_format(@activity_record.body) %>
+            <%= simple_format(@activity_record.body) %>
         </div>
     </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
-  <head>
+
+<head>
     <title><%= content_for(:title) || "Myapp" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -15,13 +16,27 @@
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-  </head>
+</head>
 
-  <body>
+<body>
     <%= render 'shared/header' %>
+
     <main class="pt-16 bg-primary-30">
-    <%= yield %>
+        <% flash.each do |key, message| %>
+        <% bg_color = (key == "notice" ? "bg-green-100 text-green-700 border-green-300" : "bg-red-100 text-red-700 border-red-300") %>
+        <div id="flash-<%= key %>"
+            class="container mx-auto px-4 py-3 border rounded-lg my-2 font-bold flex justify-between items-center <%= bg_color %>">
+            <span class="flex-1 text-center"><%= message %></span>
+            <button type="button" class="ml-4 text-xl font-bold opacity-50 hover:opacity-100"
+                onclick="this.closest('.container').remove()">
+                &times;
+            </button>
+        </div>
+        <% end %>
+
+        <%= yield %>
     </main>
     <%= render 'shared/footer' %>
-  </body>
+</body>
+
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,5 @@ Rails.application.routes.draw do
     resource :favorite, only: [ :create, :destroy ]
   end
   resources :favorites, only: [ :index ]
-  resources :activity_records, only: [ :index, :new, :create, :show, :edit, :update ]
+  resources :activity_records, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
 end


### PR DESCRIPTION
## 概要
登山記録（ActivityRecord）の削除機能を実装しました。
また、削除に伴うユーザー通知（フラッシュメッセージ）の共通化、および詳細画面のレイアウト・画像表示のUI改善をあわせて行っています。

## 変更内容
### 🛠️ 機能・バックエンド
- **ルーティングの追加:** `activity_records` のリソースに `:destroy` ルートを追加しました。
- **コントローラーの実装:** `ActivityRecordsController#destroy` を実装し、ログインユーザー自身のレコードを安全に物理削除（紐づくPhotoやActiveStorageの画像データも連動削除）する仕組みを構築しました。

### 🎨 画面・UI/UX
- **フラッシュメッセージの共通化 & 色分け:** `application.html.erb` にフラッシュ表示を共通化し、`notice`（緑）と `alert`（赤）で自動で色分けされるTailwindスタイルを適用しました。
- **任意削除機能:** インラインJavaScript（`this.closest().remove()`）を使用し、メッセージをユーザーが「×」ボタンでいつでも閉じられるようにしました。
- **詳細画面のレイアウト調整:** - タイトルと「編集・削除」ボタンを `justify-between` を使って左右の両端に綺麗に配置しました。
  - サブ画像部分を `grid-cols-2`（Gridレイアウト）と `aspect-[3/2]` に変更し、写真の枚数（1枚以下）に関わらず、常に2枚の時と同じ美しい縮尺とサイズ感をキープできるようにしました。

## 確認方法
1. 登山記録の詳細画面にアクセスし、「削除」ボタンを押した際に確認ダイアログ（ポップアップ）が表示されること。
2. ダイアログで「OK」を選択後、一覧画面にリダイレクトされ、上部に緑色で「登山記録を削除しました」と通知が表示されること。
3. 通知右側の「×」ボタンを押した際、メッセージが即座に画面から消去されること。
4. サブ画像が1枚以下のときでも、画像が巨大化せず、綺麗なアスペクト比を保ったまま2分割のサイズで表示されていること。
close #158 