### PR TITLE
Fix: 診断結果が最低値の際におすすめの山が3件表示されない状態を修正

### DIFF
--- a/app/models/mountain.rb
+++ b/app/models/mountain.rb
@@ -95,6 +95,11 @@ class Mountain < ApplicationRecord
     result += perfect.first(2)
     result += easy.first(3 - result.size) if result.size < 3
     result += challenge.first(3 - result.size) if result.size < 3
+    if result.size < 3
+      # まだ3件未満、かつ perfect にまだ使っていないデータがあるなら
+      # perfect の「3件目以降」から、足りない分（3 - result.size）を result に追加する
+      result += (perfect - result).first(3 - result.size)
+    end
 
     result
   end


### PR DESCRIPTION
## 概要
診断結果が最低値の際におすすめの山が3件表示されない状態を修正

## 内容
「診断スコアが最低値のとき、easy や challenge のグループが空になり、perfect から2件しか取得できず合計3件に満たなかった問題を修正。最後に perfect の残りから補填する処理を追加しました。」