### PR TITLE
feat: ログイン前の診断結果をログイン後に引き継ぐ機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,4 +23,24 @@ class ApplicationController < ActionController::Base
     # アカウント更新（プロフィール編集）の際に、emailとpassword以外に「name」の変更も許可する
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :avatar, :prefecture ])
   end
+
+  # Deviseが提供する、ログイン後にどこに遷移させるかを決めるメソッド
+  def after_sign_in_path_for(resource)
+    # 💡 ここで「ログイン前の診断データ」があるかどうかをチェックする
+    if session[:pending_diagnosis]
+      # 1. セッションのデータを使って、新しく Diagnosis インスタンスを作る
+      diagnosis = Diagnosis.new(session[:pending_diagnosis])
+      # 2. そのインスタンスの user を current_user (今回は引数の resource でも可) にする
+      diagnosis.user = resource
+      # 3. データベースに保存する
+      diagnosis.save!
+      # 4. セッションを空にする（消しておかないと、次回ログイン時にも反応してしまうため）
+      session.delete(:pending_diagnosis)
+      # 5. 保存した診断結果の詳細画面のパスを返す
+      diagnosis_path(diagnosis)
+    else
+      # 診断データがない場合は、通常のトップページやマイページなどのパスを返す
+      root_path # あるいは super(resource) など
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- ログイン前に診断した結果が、ログイン後にも消えずに保持されるように修正しました。

## 意図・背景
- ログイン画面に遷移した際に診断結果のデータ（セッション等）が消えてしまう挙動になっており、ユーザー体験（UI/UX）を損ねていたため。
- ログイン後もスムーズに自分の診断結果を確認・保存できるようにするため。

## 変更点（やったこと）
- `app/controllers/...` : ログイン時の処理でセッションデータを退避・復元するロジックを追加

## 影響範囲
- 未ログイン状態での診断挙動、および通常のログイン挙動

## 動作確認方法
1. 未ログイン状態で診断を実行し、結果画面が表示されることを確認。
2. そのままログイン画面へ遷移し、ログインを実行。
3. ログイン完了後、先ほどの診断結果が正しく画面に表示されていることを確認。